### PR TITLE
Update code for use with libgit2 version 1.7.0

### DIFF
--- a/examples/cat-file.cpp
+++ b/examples/cat-file.cpp
@@ -64,7 +64,7 @@ void show_blob(git::Blob const & blob)
 
 void show_tree(git::Tree const & tree)
 {
-    char oidstr[GIT_OID_HEXSZ + 1];
+    char oidstr[GIT_OID_SHA1_HEXSIZE + 1];
 
     for (size_t i = 0, n = tree.entrycount(); i < n; ++i)
     {
@@ -81,7 +81,7 @@ void show_tree(git::Tree const & tree)
 
 void show_commit(git::Commit const & commit)
 {
-    char oidstr[GIT_OID_HEXSZ + 1];
+    char oidstr[GIT_OID_SHA1_HEXSIZE + 1];
 
     git_oid_tostr(oidstr, sizeof(oidstr), &commit.tree_id());
     printf("tree %s\n", oidstr);
@@ -127,7 +127,7 @@ int main(int argc, char * argv[])
     const char *dir = ".", *rev = nullptr;
     int i, verbose = 0;
     Action action = Action::NONE;
-    char oidstr[GIT_OID_HEXSZ + 1];
+    char oidstr[GIT_OID_SHA1_HEXSIZE + 1];
 
     for (i = 1; i < argc; ++i)
     {

--- a/src/diff.cpp
+++ b/src/diff.cpp
@@ -100,7 +100,7 @@ namespace git
 
     Buffer Diff::Stats::to_buf(diff::stats::format::type format, size_t width) const
     {
-        git_buf buf = GIT_BUF_INIT_CONST(nullptr, 0);
+        git_buf buf = GIT_BUF_INIT;
         if (git_diff_stats_to_buf(&buf, stats_.get(), git_diff_stats_format_t(format.value()), width))
             throw error_t("git_diff_stats_to_buf fail");
         else

--- a/src/id_to_str.cpp
+++ b/src/id_to_str.cpp
@@ -6,12 +6,12 @@ namespace git
 {
     std::string id_to_str(git_oid const & oid)
     {
-        return id_to_str(oid, GIT_OID_HEXSZ);
+        return id_to_str(oid, GIT_OID_SHA1_HEXSIZE);
     }
 
     std::string id_to_str(git_oid const & oid, size_t digits_num)
     {
-        char buf[GIT_OID_HEXSZ + 1];
+        char buf[GIT_OID_SHA1_HEXSIZE + 1];
         git_oid_tostr(buf, sizeof(buf), &oid);
         return std::string(buf, buf + digits_num);
     }

--- a/src/repo.cpp
+++ b/src/repo.cpp
@@ -594,7 +594,7 @@ namespace git
 
     internal::optional<std::string> Repository::discover(const char * start_path)
     {
-        git_buf buf = GIT_BUF_INIT_CONST(nullptr, 0);
+        git_buf buf = GIT_BUF_INIT;
         if (git_repository_discover(&buf, start_path, 0, nullptr))
             return internal::none;
         return std::string(buf.ptr, buf.size);


### PR DESCRIPTION
Simple changes that enable libgit2cpp to compile for the latest version (presently 1.70) of libgit2.