### PR TITLE
generalize gitignore for default clion cmake build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 *.swo
 build
 *.user
-cmake-build-debug/
-cmake-build-release/
+cmake-build*/
 .idea/


### PR DESCRIPTION
this generalizes the clion build dir entries in the `.gitignore` to cover all default build folder names

_clion will create a folder for each cmake profile you create, by default they are named `cmake-build-[PROFILENAME]`, so you could have more than two and some that are named something other than debug or release_