### PR TITLE
use IMPORTED_TARGET for pkg_search_module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.6)
 
 project(libgit2cpp LANGUAGES C CXX)
 set(package git2cpp)
@@ -56,8 +56,8 @@ if (BUNDLE_LIBGIT2)
     target_link_libraries(${package} libgit2package)
 else ()
     find_package(PkgConfig REQUIRED)
-    pkg_search_module(LibGit2 REQUIRED libgit2)
-    target_link_libraries(${package} ${LibGit2_LIBRARIES})
+    pkg_search_module(LibGit2 REQUIRED IMPORTED_TARGET libgit2)
+    target_link_libraries(${package} PkgConfig::LibGit2)
 endif ()
 
 include(InstallRules)


### PR DESCRIPTION
this changes `pkg_search_module` to use the `IMPORTED_TARGET` argument to look for LibGit2, to support the use of libgit2 via vcpkg

using `IMPORTED_TARGET` and the created `PkgConfig::<prefix>` target is more concise _and "modern"_ than using `<XXX>_LINK_LIBRARIES` and `<XXX>_INCLUDE_DIRS`
it does however require a version bump for minimum cmake to `3.6` _from `3.5.1` before_, if that is not desirable it could be changed to not use `IMPORTED_TARGET`

tested with `BUNDLE_LIBGIT2=OFF` on Windows _(msvc & vcpkg)_, WSL Arch _(gcc & sys package)_ and WLS Ubuntu _(clang & vcpkg)_